### PR TITLE
Error handling in deploy fix

### DIFF
--- a/contract-builder/template/deploy.sh
+++ b/contract-builder/template/deploy.sh
@@ -39,7 +39,7 @@ do
 done
 
 # Need this to fail the script on error for sure
-set +e
+set -e
 
 # Install Node
 if ! which node >/dev/null; then
@@ -118,7 +118,7 @@ else
 fi
 
 # The rest fails OK
-set -e
+set +e
 
 # Install node packages
 echo "Fetching OpenZeppelin contracts"


### PR DESCRIPTION
We use `set -e` if we want interruption on error, and `set +e` if we ignore errors.

Little quote from `man bash`

> -e
> Exit immediately if a pipeline (which may consist of a single simple command), a subshell command enclosed in parentheses, or one of the commands executed as part of a command list enclosed by braces exits with a non-zero status.