### PR TITLE
Add language to mobx store, react-intl, test one string, toggle lang

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
   "dependencies": {
     "@craco/craco": "^6.1.1",
     "axios": "^0.21.1",
+    "cross-env": "^7.0.3",
     "mobx": "^6.3.0",
     "mobx-react-lite": "^3.2.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-input-mask": "^2.0.4",
+    "react-intl": "^5.18.0",
     "react-scripts": "4.0.3",
     "swr": "^0.5.6",
     "tailwindcss-classnames": "^2.0.7",
@@ -18,7 +20,7 @@
     "web3": "^1.3.5"
   },
   "scripts": {
-    "start": "BROWSER=none craco start",
+    "start": "cross-env BROWSER=none craco start",
     "start-win": "SET BROWSER=none & craco start",
     "build": "NODE_ENV=production BUILD_PATH='./docs' craco build",
     "build-win": "SET NODE_ENV=production & SET BUILD_PATH='./docs' & craco build",
@@ -53,10 +55,10 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@types/web3": "^1.2.2",
-    "autoprefixer": "^9",
-    "postcss": "^7",
+    "autoprefixer": "^9.8.6",
+    "postcss": "^7.0.35",
     "prettier": "2.2.1",
-    "tailwindcss": "npm:@tailwindcss/postcss7-compat",
+    "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.1.2",
     "typescript": "^4.1.2"
   }
 }

--- a/src/components/ContractWallet/index.tsx
+++ b/src/components/ContractWallet/index.tsx
@@ -23,6 +23,8 @@ import { web3Store } from "store/web3.store"
 import { userStore } from "store/user.store"
 import useSWR from "swr"
 import { fetcher } from "helpers/fetcher.helper"
+import { IntlProvider, FormattedMessage } from "react-intl"
+import { langStore } from "store/language.store"
 
 const ContractWallet: FC = () => {
   const [adressDisabled, setAdressDisabled] = useState<boolean>(true)
@@ -97,7 +99,16 @@ const ContractWallet: FC = () => {
           </div>
           {appStore.currentNetwork === AppNetworks.Test && (
             <button className={addButtonStyle}>
-              Get test ETH to your wallet
+              <IntlProvider
+                locale={langStore.currentLanguage}
+                defaultLocale="en"
+                messages={langStore.loadLocaleData(langStore.currentLanguage)}
+              >
+                <FormattedMessage
+                  id="subtitleBalance"
+                  defaultMessage="Get test ETH to your wallet"
+                />
+              </IntlProvider>
             </button>
           )}
         </div>

--- a/src/components/Navigation/index.tsx
+++ b/src/components/Navigation/index.tsx
@@ -1,11 +1,21 @@
 import { observer } from "mobx-react-lite"
 import React, { FC } from "react"
 import { AppNetworks, appStore } from "store/app.store"
+import { langStore } from "store/language.store"
 import { buttonStyleReal, buttonStyleTest } from "./styles"
 
 const Navigation: FC = () => {
   return (
     <nav>
+      <button
+        onClick={() => langStore.toggleLanguage()}
+        className={
+          langStore.currentLanguage === "en" ? buttonStyleReal : buttonStyleTest
+        }
+      >
+        {langStore.currentLanguage === "en" && "English"}
+        {langStore.currentLanguage === "ru" && "Русский"}
+      </button>
       <button
         onClick={() => appStore.toggleNetwork()}
         className={

--- a/src/store/language.store.ts
+++ b/src/store/language.store.ts
@@ -1,0 +1,36 @@
+import { makeAutoObservable } from "mobx"
+
+const messagesInRussian = {
+  subtitleBalance: "Возьмите на тест ETH в кошелек",
+}
+
+const messagesInEnglish = {
+  subtitleBalance: "Get test ETH to your wallet",
+}
+
+class LanguageStore {
+  currentLanguage: string = "en"
+
+  constructor() {
+    makeAutoObservable(this)
+  }
+
+  toggleLanguage() {
+    this.currentLanguage = this.currentLanguage === "en" ? "ru" : "en"
+  }
+
+  loadLocaleData(locale: string) {
+    switch (locale) {
+      case "ru":
+        this.currentLanguage = "ru"
+        // return import("../lang/ru.json")
+        return messagesInRussian
+      default:
+        this.currentLanguage = "en"
+        // return import("../lang/en-US.json")
+        return messagesInEnglish
+    }
+  }
+}
+
+export const langStore = new LanguageStore()


### PR DESCRIPTION
- add language to mobx store
- add i18n (react-intl). Now use only 'en' and 'ru'. And else not use files in json.
- write example for translation one strings - button "Get test ETH to your wallet" - just for check of true way
- add a language toggle - for check, without styling
